### PR TITLE
DoubleArray#getChild: use `code` instead of `c` to calculate a new index value

### DIFF
--- a/trie4j/src/main/java/org/trie4j/doublearray/DoubleArray.java
+++ b/trie4j/src/main/java/org/trie4j/doublearray/DoubleArray.java
@@ -166,7 +166,7 @@ implements Externalizable, TermIdTrie{
 		public DoubleArrayNode getChild(char c) {
 			int code = charToCode[c];
 			if(code == -1) return null;
-			int nid = base[nodeId] + c;
+			int nid = base[nodeId] + code;
 			if(nid >= 0 && nid < check.length && check[nid] == nodeId) return new DoubleArrayNode(nid, c);
 			return null;
 		}


### PR DESCRIPTION
Hi,

I found a bug in the DoubleArray#getChild method. In the method, we should use the variable `code` to calculate a new index value. This PR will fix the issue.

P.S. Thanks for referencing my book in the README, I'm really honored :)