### PR TITLE
fix: a never execution of `if` block

### DIFF
--- a/trie4j/src/main/java/org/trie4j/io/TrieWriter.java
+++ b/trie4j/src/main/java/org/trie4j/io/TrieWriter.java
@@ -154,7 +154,7 @@ public class TrieWriter implements Constants{
 		} else if(sbv instanceof BytesRank1OnlySuccinctBitVector){
 			dos.writeShort(TYPE_SBV_RANK1ONLY);
 			writeRank1OnlySuccinctBitVector((BytesRank1OnlySuccinctBitVector)sbv);
-		} else if(sbv instanceof BytesRank1OnlySuccinctBitVector){
+		} else if(sbv instanceof LongsSuccinctBitVector){
 			dos.writeShort(TYPE_SBV_LONGS);
 			writeLongsSuccinctBitVector((LongsSuccinctBitVector)sbv);
 		} else {


### PR DESCRIPTION
- There is a duplication of `instanceof` check in `if` block that is never executed.
 
- The block has a problem which Spotbugs report as BC issue
    - it is impossible to cast from `org.trie4j.bv.BytesRank1OnlySuccinctBitVector` to `org.trie4j.bv.LongsSuccinctBitVector` at `org.trie4j.io.TrieWriter.writeSuccinctBitVector(SuccinctBitVector)`.

- This looks a typo of `instanceof` check